### PR TITLE
Update atomic.AddInt64() to RWMutex to avoid atomic.AddInt64() crash

### DIFF
--- a/lib/monitor.go
+++ b/lib/monitor.go
@@ -2,7 +2,9 @@ package lib
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 )
 
@@ -70,12 +72,25 @@ func (m *Monitor) setScanEnd() {
 	m.seekAheadEnd = true
 }
 
+func addInt64(goarch string, src *int64, delta int64) int64 {
+	if goarch == "386" || goarch == "arm64" {
+		var mu sync.RWMutex
+		mu.Lock()
+		*src += delta
+		mu.Unlock()
+	} else { // For amd64, arm64
+		atomic.AddInt64(src, delta)
+	}
+
+	return *src
+}
+
 func (m *Monitor) updateOKNum(num int64) {
-	atomic.AddInt64(&m.okNum, num)
+	addInt64(runtime.GOARCH, &m.okNum, num)
 }
 
 func (m *Monitor) updateErrNum(num int64) {
-	atomic.AddInt64(&m.errNum, num)
+	addInt64(runtime.GOARCH, &m.errNum, num)
 }
 
 func (m *Monitor) getSnapshot() *MonitorSnap {
@@ -220,19 +235,19 @@ func (m *RMMonitor) setScanEnd() {
 }
 
 func (m *RMMonitor) updateObjectNum(num int64) {
-	atomic.AddInt64(&m.objectNum, num)
+	addInt64(runtime.GOARCH, &m.objectNum, num)
 }
 
 func (m *RMMonitor) updateUploadIdNum(num int64) {
-	atomic.AddInt64(&m.uploadIdNum, num)
+	addInt64(runtime.GOARCH, &m.uploadIdNum, num)
 }
 
 func (m *RMMonitor) updateErrObjectNum(num int64) {
-	atomic.AddInt64(&m.errObjectNum, num)
+	addInt64(runtime.GOARCH, &m.errObjectNum, num)
 }
 
 func (m *RMMonitor) updateErrUploadIdNum(num int64) {
-	atomic.AddInt64(&m.errUploadIdNum, num)
+	addInt64(runtime.GOARCH, &m.errUploadIdNum, num)
 }
 
 func (m *RMMonitor) updateRemovedBucket(bucket string) {
@@ -425,27 +440,27 @@ func (m *CPMonitor) setScanEnd() {
 }
 
 func (m *CPMonitor) updateTransferSize(size int64) {
-	atomic.AddInt64(&m.transferSize, size)
+	addInt64(runtime.GOARCH, &m.transferSize, size)
 }
 
 func (m *CPMonitor) updateFile(size, num int64) {
-	atomic.AddInt64(&m.fileNum, num)
-	atomic.AddInt64(&m.transferSize, size)
+	addInt64(runtime.GOARCH, &m.fileNum, num)
+	addInt64(runtime.GOARCH, &m.transferSize, size)
 }
 
 func (m *CPMonitor) updateDir(size, num int64) {
-	atomic.AddInt64(&m.dirNum, num)
-	atomic.AddInt64(&m.transferSize, size)
+	addInt64(runtime.GOARCH, &m.dirNum, num)
+	addInt64(runtime.GOARCH, &m.transferSize, size)
 }
 
 func (m *CPMonitor) updateSkip(size, num int64) {
-	atomic.AddInt64(&m.skipNum, num)
-	atomic.AddInt64(&m.skipSize, size)
+	addInt64(runtime.GOARCH, &m.skipNum, num)
+	addInt64(runtime.GOARCH, &m.skipSize, size)
 }
 
 func (m *CPMonitor) updateErr(size, num int64) {
-	atomic.AddInt64(&m.errNum, num)
-	atomic.AddInt64(&m.transferSize, size)
+	addInt64(runtime.GOARCH, &m.errNum, num)
+	addInt64(runtime.GOARCH, &m.transferSize, size)
 }
 
 func (m *CPMonitor) getSnapshot() *CPMonitorSnap {

--- a/lib/monitor_test.go
+++ b/lib/monitor_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -1838,6 +1839,11 @@ func (s *OssutilCommandSuite) TestRangeGet(c *C) {
 	str = s.readFile(dir+string(os.PathSeparator)+object1, c)
 	c.Assert(str, Equals, data1[25:])
 
+	fmt.Println(bucketName)
+	fmt.Println(dir)
+	fmt.Println(object)
+	fmt.Println(object1)
+
 	snap = copyCommand.monitor.getSnapshot()
 	c.Assert(copyCommand.monitor.totalSize == int64(10) || !copyCommand.monitor.seekAheadEnd, Equals, true)
 	c.Assert(copyCommand.monitor.totalNum == int64(2) || !copyCommand.monitor.seekAheadEnd, Equals, true)
@@ -1902,4 +1908,26 @@ func (s *OssutilCommandSuite) TestRangeGet(c *C) {
 
 	os.RemoveAll(dir)
 	s.removeBucket(bucketName, true, c)
+}
+
+func (s *OssutilCommandSuite) TestAddInt64(c *C) {
+	src := rand.Int63n(10000)
+	delta := rand.Int63n(1000)
+	result := addInt64("386", &src, delta)
+	c.Assert(src+delta == result)
+
+	src = rand.Int63n(20000)
+	delta = rand.Int63n(2000)
+	result = addInt64("amd64", &src, delta)
+	c.Assert(src+delta == result)
+
+	src = rand.Int63n(30000)
+	delta = rand.Int63n(3000)
+	result = addInt64("arm", &src, delta)
+	c.Assert(src+delta == result)
+
+	src = rand.Int63n(40000)
+	delta = rand.Int63n(4000)
+	result = addInt64("arm64", &src, delta)
+	c.Assert(src+delta == result)
 }


### PR DESCRIPTION
on 32bits or 64bits OS when running 32bits ossutil