### PR TITLE
[config_helper] Do not get current user if not needed

### DIFF
--- a/lib/config_helper.go
+++ b/lib/config_helper.go
@@ -53,9 +53,9 @@ func DecideConfigFile(configFile string) string {
 	if configFile == "" {
 		configFile = DefaultConfigFile
 	}
-	usr, _ := user.Current()
-	dir := usr.HomeDir
 	if len(configFile) >= 2 && strings.HasPrefix(configFile, "~"+string(os.PathSeparator)) {
+		usr, _ := user.Current()
+		dir := usr.HomeDir
 		configFile = strings.Replace(configFile, "~", dir, 1)
 	}
 	return configFile


### PR DESCRIPTION
In some special environments in Kubernetes it's not possible to get current user. So you have to pass config path as an argument, but this check crashes the ossutil since `usr` would be null.