### PR TITLE
Preview 1.6.13

### DIFF
--- a/lib/command_test.go
+++ b/lib/command_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/user"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -1596,12 +1595,11 @@ func (s *OssutilCommandSuite) TestNotExistCommand(c *C) {
 }
 
 func (s *OssutilCommandSuite) TestDecideConfigFile(c *C) {
-	usr, _ := user.Current()
 	file := DecideConfigFile("")
-	c.Assert(file, Equals, strings.Replace(DefaultConfigFile, "~", usr.HomeDir, 1))
+	c.Assert(file, Equals, strings.Replace(DefaultConfigFile, "~", currentHomeDir(), 1))
 	input := "~" + string(os.PathSeparator) + "a"
 	file = DecideConfigFile(input)
-	c.Assert(file, Equals, strings.Replace(input, "~", usr.HomeDir, 1))
+	c.Assert(file, Equals, strings.Replace(input, "~", currentHomeDir(), 1))
 }
 
 func (s *OssutilCommandSuite) TestCheckConfig(c *C) {
@@ -1699,8 +1697,7 @@ func (s *OssutilCommandSuite) TestStorageURL(c *C) {
 	c.Assert(cloudURL.bucket, Equals, "abc")
 	c.Assert(cloudURL.object, Equals, "d")
 
-	usr, _ := user.Current()
-	dir := usr.HomeDir
+	dir := currentHomeDir()
 	url := "~" + string(os.PathSeparator) + "test"
 	var fileURL FileURL
 	fileURL.Init(url, "")

--- a/lib/config_helper.go
+++ b/lib/config_helper.go
@@ -3,7 +3,6 @@ package lib
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"strconv"
 	"strings"
 
@@ -62,9 +61,9 @@ func DecideConfigFile(configFile string) string {
 	}
 
 	if len(configFile) >= 2 && strings.HasPrefix(configFile, "~"+string(os.PathSeparator)) {
-		usr, _ := user.Current()
-		if usr != nil {
-			configFile = strings.Replace(configFile, "~", usr.HomeDir, 1)
+		homeDir := currentHomeDir()
+		if homeDir != "" {
+			configFile = strings.Replace(configFile, "~", homeDir, 1)
 		}
 	}
 	return configFile

--- a/lib/const.go
+++ b/lib/const.go
@@ -125,7 +125,7 @@ const (
 const (
 	Package                 string = "ossutil"
 	ChannelBuf              int    = 1000
-	Version                 string = "v1.6.12"
+	Version                 string = "v1.6.13"
 	DefaultEndpoint         string = "oss.aliyuncs.com"
 	ChineseLanguage                = "CH"
 	EnglishLanguage                = "EN"

--- a/lib/cp.go
+++ b/lib/cp.go
@@ -2502,8 +2502,8 @@ func (cc *CopyCommand) skipDownload(fileName string, srcModifiedTime time.Time, 
 		}
 	} else {
 		if !cc.cpOption.force {
-			if _, err := os.Stat(fileName); err == nil {
-				if !cc.confirm(fileName) {
+			if fileInfo, err := os.Stat(fileName); err == nil {
+				if fileInfo.IsDir() || !cc.confirm(fileName) {
 					return true
 				}
 			}

--- a/lib/ossutil_log.go
+++ b/lib/ossutil_log.go
@@ -37,7 +37,7 @@ func InitLogger(level int, name string) {
 	if err != nil {
 		return
 	}
-	utilLogger = log.New(f, "", log.LstdFlags)
+	utilLogger = log.New(f, "", log.LstdFlags|log.Lmicroseconds)
 	logFile = f
 }
 

--- a/lib/storage_url.go
+++ b/lib/storage_url.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/user"
 	"strings"
 )
 
@@ -138,11 +137,11 @@ func (fu *FileURL) Init(urlStr, encodingType string) error {
 	}
 
 	if len(urlStr) >= 2 && urlStr[:2] == "~"+string(os.PathSeparator) {
-		usr, err := user.Current()
-		if usr != nil {
-			urlStr = strings.Replace(urlStr, "~", usr.HomeDir, 1)
+		homeDir := currentHomeDir()
+		if homeDir != "" {
+			urlStr = strings.Replace(urlStr, "~", homeDir, 1)
 		} else {
-			return fmt.Errorf("%s,get current user error for ~", err.Error())
+			return fmt.Errorf("current home dir is empty")
 		}
 	}
 	fu.urlStr = urlStr


### PR DESCRIPTION
1、cp命令下载只有文件才提示是否覆盖
2、windows平台使用GetEnv替换current.User 获取home目录
3、优化user agent，启动时候获取一次即可，不用每次请求都获取。
4、日志文件精确到毫秒