### PR TITLE
fix set-meta which always set object acl to default

### DIFF
--- a/lib/const.go
+++ b/lib/const.go
@@ -129,7 +129,7 @@ const (
 const (
 	Package                 string = "ossutil"
 	ChannelBuf              int    = 1000
-	Version                 string = "v1.6.18"
+	Version                 string = "v1.6.19"
 	DefaultEndpoint         string = "oss.aliyuncs.com"
 	ChineseLanguage                = "CH"
 	EnglishLanguage                = "EN"

--- a/lib/util.go
+++ b/lib/util.go
@@ -519,6 +519,8 @@ func currentHomeDir() string {
 	usr, _ := user.Current()
 	if usr != nil {
 		homeDir = usr.HomeDir
+	} else {
+		homeDir = os.Getenv("HOME")
 	}
 	return homeDir
 }


### PR DESCRIPTION
fix set-meta which always set object acl to default